### PR TITLE
Fix bug for callback not work when mutliple request

### DIFF
--- a/permissionx/src/main/java/com/permissionx/guolindev/request/InvisibleFragment.java
+++ b/permissionx/src/main/java/com/permissionx/guolindev/request/InvisibleFragment.java
@@ -108,6 +108,10 @@ public class InvisibleFragment extends Fragment {
         } else if (requestType == REQUEST_BACKGROUND_LOCATION_PERMISSION) {
             onRequestBackgroundLocationPermissionResult(requestCode);
         }
+        requestInfoMap.remove(requestCode);
+        if (requestInfoMap.isEmpty() && getFragmentManager() != null) {
+            getFragmentManager().beginTransaction().remove(this).commitNowAllowingStateLoss();
+        }
     }
 
     /**

--- a/permissionx/src/main/java/com/permissionx/guolindev/request/PermissionBuilder.java
+++ b/permissionx/src/main/java/com/permissionx/guolindev/request/PermissionBuilder.java
@@ -219,10 +219,9 @@ public class PermissionBuilder {
 
     /**
      * Set the tint color to the default rationale dialog.
-     * @param lightColor
-     *          Used in light theme. A color value in the form 0xAARRGGBB. Do not pass a resource ID. To get a color value from a resource ID, call getColor.
-     * @param darkColor
-     *          Used in dark theme. A color value in the form 0xAARRGGBB. Do not pass a resource ID. To get a color value from a resource ID, call getColor.
+     *
+     * @param lightColor Used in light theme. A color value in the form 0xAARRGGBB. Do not pass a resource ID. To get a color value from a resource ID, call getColor.
+     * @param darkColor  Used in dark theme. A color value in the form 0xAARRGGBB. Do not pass a resource ID. To get a color value from a resource ID, call getColor.
      * @return PermissionBuilder itself.
      */
     public PermissionBuilder setDialogTintColor(int lightColor, int darkColor) {
@@ -294,7 +293,7 @@ public class PermissionBuilder {
                 if (showReasonOrGoSettings) {
                     chainTask.requestAgain(permissions);
                 } else {
-                    forwardToSettings(permissions);
+                    forwardToSettings(permissions, chainTask);
                 }
             }
         });
@@ -344,7 +343,7 @@ public class PermissionBuilder {
                 if (showReasonOrGoSettings) {
                     chainTask.requestAgain(permissions);
                 } else {
-                    forwardToSettings(permissions);
+                    forwardToSettings(permissions, chainTask);
                 }
             }
         });
@@ -415,13 +414,13 @@ public class PermissionBuilder {
      *
      * @param permissions Permissions which are necessary.
      */
-    private void forwardToSettings(List<String> permissions) {
+    private void forwardToSettings(List<String> permissions, ChainTask task) {
         forwardPermissions.clear();
         forwardPermissions.addAll(permissions);
         Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
         Uri uri = Uri.fromParts("package", activity.getPackageName(), null);
         intent.setData(uri);
-        getInvisibleFragment().startActivityForResult(intent, InvisibleFragment.FORWARD_TO_SETTINGS);
+        getInvisibleFragment().requestToSettingPage(intent, InvisibleFragment.FORWARD_TO_SETTINGS, this, task);
     }
 
 }

--- a/permissionx/src/main/java/com/permissionx/guolindev/request/RequestInfo.kt
+++ b/permissionx/src/main/java/com/permissionx/guolindev/request/RequestInfo.kt
@@ -1,0 +1,3 @@
+package com.permissionx.guolindev.request
+
+data class RequestInfo(val pb: PermissionBuilder, val task: ChainTask)


### PR DESCRIPTION
I fix the error of sending multiple permission at the same time in this commit
As the follow code, the second request's callback will be used in the first permission request.
```java
PermissionX.init(MainJavaActivity.this)
          .permissions(Manifest.permission.WRITE_EXTERNAL_STORAGE)
          .request(new RequestCallback() {
              @Override
              public void onResult(boolean allGranted, List<String> grantedList, List<String> deniedList) {
                  //do something
              }
          });
PermissionX.init(MainJavaActivity.this)
        .permissions(Manifest.permission.WRITE_EXTERNAL_STORAGE)
        .request(new RequestCallback() {
            @Override
            public void onResult(boolean allGranted, List<String> grantedList, List<String> deniedList) {
                //do something
            }
        });
```