### PR TITLE
在不改动原有代码结构基础上，增加一点扩展，使其用任意可启动activity的context申请权限，不必强求activity继承自FragmentActivity。

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,14 +36,18 @@
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_WAP_PUSH" />
     <uses-permission android:name="android.permission.RECEIVE_MMS" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+    <uses-permission
+        android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
@@ -53,9 +57,9 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"/>
-    <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
+    <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND" />
 
     <application
         android:allowBackup="true"
@@ -64,20 +68,25 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <!--        <activity android:name=".MainJavaActivity" android:exported="true">
-                <intent-filter>
-                    <action android:name="android.intent.action.MAIN" />
+        <activity
+            android:name=".MainJavaActivity"
+            android:exported="true">
+            <!--    <intent-filter>
+                  <action android:name="android.intent.action.MAIN" />
 
-                    <category android:name="android.intent.category.LAUNCHER" />
-                </intent-filter>
-            </activity>-->
-        <activity android:name=".MainActivity" android:exported="true">
+                  <category android:name="android.intent.category.LAUNCHER" />
+              </intent-filter>-->
+        </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="com.permissionx.app.ExampleComponentActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/permissionx/app/ExampleComponentActivity.kt
+++ b/app/src/main/java/com/permissionx/app/ExampleComponentActivity.kt
@@ -1,37 +1,44 @@
 package com.permissionx.app
 
 import android.Manifest
-import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
-import androidx.fragment.app.Fragment
-import com.permissionx.app.databinding.FragmentMainBinding
+import androidx.activity.ComponentActivity
+import com.permissionx.app.databinding.ActivityExampleComponentBinding
 import com.permissionx.guolindev.PermissionX
+import com.permissionx.guolindev.patch.PermissionDelegateHolder
 
-class MainFragment : Fragment() {
+class ExampleComponentActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val layout = ActivityExampleComponentBinding.inflate(layoutInflater)
+        layout.makeRequestBtn.setOnClickListener {
 
-    private var _binding: FragmentMainBinding? = null
-
-    private val binding get() = _binding!!
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        _binding = FragmentMainBinding.inflate(inflater, container, false)
-        return binding.root
+            PermissionX.init(this) {
+                it.permissions(Manifest.permission.CAMERA)
+                    .request { allGranted, grantedList, deniedList ->
+                        if (allGranted) {
+                            Toast.makeText(this, "All permissions are granted", Toast.LENGTH_SHORT)
+                                .show()
+                        } else {
+                            Toast.makeText(
+                                this,
+                                "The following permissions are denied：$deniedList",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+            }
+            // or directly use PermissionDelegateHolder
+//            requestPerms()
+        }
+        setContentView(layout.root)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-//        val context = context!!
-        binding.makeRequestBtn.setOnClickListener {
-            PermissionX.init(this)
+    fun requestPerms() {
+        PermissionDelegateHolder.delegate(this) {
+            PermissionX.init(it)
                 .permissions(
                     Manifest.permission.CAMERA,
                     Manifest.permission.ACCESS_FINE_LOCATION,
@@ -59,38 +66,16 @@ class MainFragment : Fragment() {
                 }
                 .request { allGranted, grantedList, deniedList ->
                     if (allGranted) {
-                        Toast.makeText(activity, "All permissions are granted", Toast.LENGTH_SHORT)
+                        Toast.makeText(it, "All permissions are granted", Toast.LENGTH_SHORT)
                             .show()
                     } else {
                         Toast.makeText(
-                            activity,
+                            it,
                             "The following permissions are denied：$deniedList",
                             Toast.LENGTH_SHORT
                         ).show()
                     }
                 }
         }
-        binding.makeRequestBtn2.setOnClickListener {
-            requireActivity().startActivity(
-                Intent(
-                    requireActivity(),
-                    ExampleComponentActivity::class.java
-                )
-            )
-        }
-        binding.makeRequestBtn3.setOnClickListener {
-            requireActivity().startActivity(
-                Intent(
-                    requireActivity(),
-                    MainJavaActivity::class.java
-                )
-            )
-        }
     }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
-
 }

--- a/app/src/main/java/com/permissionx/app/MainJavaActivity.java
+++ b/app/src/main/java/com/permissionx/app/MainJavaActivity.java
@@ -5,9 +5,15 @@ import android.os.Bundle;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 
 import com.permissionx.app.databinding.ActivityMainJavaBinding;
+import com.permissionx.guolindev.PermissionMediator;
 import com.permissionx.guolindev.PermissionX;
+import com.permissionx.guolindev.patch.PermissionDelegateHolder;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 
 public class MainJavaActivity extends AppCompatActivity {
 
@@ -16,11 +22,40 @@ public class MainJavaActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         ActivityMainJavaBinding binding = ActivityMainJavaBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        binding.makeRequestBtn.setOnClickListener(view -> PermissionX.init(MainJavaActivity.this)
+
+        binding.makeRequestBtn.setOnClickListener(view -> {
+            requestCameraPermission(MainJavaActivity.this);
+        });
+
+        binding.makeRequestBtn2.setOnClickListener(view -> {
+            PermissionX.init(this, permissionMediator -> {
+                permissionMediator
+                        .permissions(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        .explainReasonBeforeRequest()
+                        .request((allGranted, grantedList, deniedList) -> {
+                            if (allGranted) {
+                                Toast.makeText(MainJavaActivity.this, "All permissions are granted", Toast.LENGTH_SHORT).show();
+                            } else {
+                                Toast.makeText(MainJavaActivity.this, "The following permissions are denied：" + deniedList, Toast.LENGTH_SHORT).show();
+                            }
+                        });
+                return null;
+            });
+
+            // or directly use PermissionDelegateHolder
+//            PermissionDelegateHolder.delegate(this, fragmentActivity -> {
+//                requestCameraPermission(fragmentActivity);// use the activity argument, do not use MainJavaActivity.this
+//                return null;
+//            });
+        });
+    }
+
+    private void requestCameraPermission(FragmentActivity activity) {
+        PermissionX.init(activity)
                 .permissions(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 .explainReasonBeforeRequest()
                 .onExplainRequestReason((scope, deniedList, beforeRequest) -> {
-//                    CustomDialog customDialog = new CustomDialog(MainJavaActivity.this, "PermissionX needs following permissions to continue", deniedList);
+//                    CustomDialog customDialog = new CustomDialog(activity, "PermissionX needs following permissions to continue", deniedList);
 //                    scope.showRequestReasonDialog(customDialog);
                     scope.showRequestReasonDialog(deniedList, "PermissionX needs following permissions to continue", "Allow");
                 })
@@ -33,6 +68,6 @@ public class MainJavaActivity extends AppCompatActivity {
                     } else {
                         Toast.makeText(MainJavaActivity.this, "The following permissions are denied：" + deniedList, Toast.LENGTH_SHORT).show();
                     }
-                }));
+                });
     }
 }

--- a/app/src/main/res/layout/activity_example_component.xml
+++ b/app/src/main/res/layout/activity_example_component.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/makeRequestBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="Request Permissions" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main_java.xml
+++ b/app/src/main/res/layout/activity_main_java.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:background="?android:attr/colorBackground">
 
     <Button
@@ -10,5 +11,12 @@
         android:layout_height="wrap_content"
         android:textAllCaps="false"
         android:text="Make Request" />
+
+    <Button
+        android:id="@+id/makeRequestBtn2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="Make Request2 use PermissionDelegateHolder" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:background="?android:attr/colorBackground">
 
     <Button
@@ -10,5 +11,19 @@
         android:layout_height="wrap_content"
         android:textAllCaps="false"
         android:text="Make Request" />
+
+    <Button
+        android:id="@+id/makeRequestBtn2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="open ComponentActivity" />
+
+    <Button
+        android:id="@+id/makeRequestBtn3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="MainJavaActivity" />
 
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.1"
+agp = "8.5.1"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 29 21:48:04 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/permissionx/src/main/AndroidManifest.xml
+++ b/permissionx/src/main/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <activity android:name="com.permissionx.guolindev.patch.DelegateActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            />
+    </application>
 </manifest>

--- a/permissionx/src/main/java/com/permissionx/guolindev/PermissionX.java
+++ b/permissionx/src/main/java/com/permissionx/guolindev/PermissionX.java
@@ -16,6 +16,7 @@
 
 package com.permissionx.guolindev;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
@@ -24,6 +25,11 @@ import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
+
+import com.permissionx.guolindev.patch.PermissionDelegateHolder;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 
 /**
  * An open source Android library that makes handling runtime permissions extremely easy.
@@ -36,6 +42,18 @@ import androidx.fragment.app.FragmentActivity;
  *          // handling the logic
  *      }
  *</pre>
+ *
+ * if you are using component activity, you can use the following snippet:
+ * <pre>
+ * PermissionX.init(this, permissionMediator -> {
+ *     permissionMediator
+ *          .permissions(Manifest.permission.READ_CONTACTS, Manifest.permission.CAMERA)
+ *          .request { allGranted, grantedList, deniedList ->
+ *              // handling the logic
+ *          }
+ *     return null;
+ * });
+ * </pre>
  *
  * @author guolin
  * @since 2019/11/2
@@ -60,6 +78,21 @@ public class PermissionX {
      */
     public static PermissionMediator init(@NonNull Fragment fragment) {
         return new PermissionMediator(fragment);
+    }
+
+    /**
+     * Init PermissionX to make everything prepare to work.
+     * request permissions in a component activity.
+     *
+     * @param context the context which can launch a new activity
+     * @param block the request permissions block to be executed
+     */
+    public static void init(@NonNull Context context, @NonNull Function1<PermissionMediator, Unit> block) {
+        PermissionDelegateHolder.delegate(context, fragmentActivity -> {
+            PermissionMediator permissionMediator = new PermissionMediator(fragmentActivity);
+            block.invoke(permissionMediator);
+            return null;
+        });
     }
 
     /**

--- a/permissionx/src/main/java/com/permissionx/guolindev/patch/DelegateActivity.kt
+++ b/permissionx/src/main/java/com/permissionx/guolindev/patch/DelegateActivity.kt
@@ -1,0 +1,51 @@
+package com.permissionx.guolindev.patch
+
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.fragment.app.FragmentActivity
+import java.util.UUID
+
+/**
+ * Delegate activity
+ *
+ * author: knightwood
+ */
+class DelegateActivity : FragmentActivity() {
+    private lateinit var uuid: UUID
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        window.setBackgroundDrawableResource(android.R.color.transparent)
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        window.statusBarColor = Color.TRANSPARENT
+
+
+        uuid = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getSerializableExtra("uuid", UUID::class.java)!!
+        } else {
+            intent.getSerializableExtra("uuid") as UUID
+        }
+
+        supportFragmentManager.setFragmentResultListener(
+            PermissionDelegateHolder.REQUEST_KEY,
+            this,
+        ) { _, bundle ->
+            val result = bundle.getBoolean(PermissionDelegateHolder.RESULT_KEY)
+            if (result) // Hahaha, in fact it will never be false here
+                release()
+        }
+
+        //execute permission request
+        PermissionDelegateHolder.holder[uuid]!!.invoke(this)
+    }
+
+    private fun release() {
+        PermissionDelegateHolder.holder.remove(uuid)
+        finish()
+    }
+
+}

--- a/permissionx/src/main/java/com/permissionx/guolindev/patch/PermissionDelegateHolder.kt
+++ b/permissionx/src/main/java/com/permissionx/guolindev/patch/PermissionDelegateHolder.kt
@@ -1,0 +1,62 @@
+package com.permissionx.guolindev.patch
+
+import android.content.Context
+import android.content.Intent
+import androidx.fragment.app.FragmentActivity
+import java.util.UUID
+
+/**
+ * Permission Delegate Holder
+ *
+ * author: knightwood
+ *
+ * in component activity, you can call this method to request permissions.
+ */
+object PermissionDelegateHolder {
+    const val REQUEST_KEY = "RequestFinish"
+    const val RESULT_KEY = "Result"
+
+    internal val holder: MutableMap<UUID, (activity: FragmentActivity) -> Unit> = HashMap()
+
+    /**
+     * request permissions in a component activity.
+     *
+     * kotlin example:
+     * ```
+     * PermissionDelegateHolder.delegate(this) { activity ->
+     *   PermissionX.init(activity)// use activity parameter to init PermissionX, do not use outside activity
+     *      .permissions(Manifest.permission.READ_CONTACTS, Manifest.permission.CAMERA)
+     *      .request { allGranted, grantedList, deniedList ->
+     *          // handling the logic
+     *      }
+     * }
+     *
+     * ```
+     *
+     * java example:
+     * ```
+     * PermissionDelegateHolder.delegate(this, activity -> {
+     *     PermissionX.init(activity) // use activity parameter to init PermissionX, do not use outside activity
+     *        .permissions(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+     *        .request((allGranted, grantedList, deniedList) -> {
+     *            if (allGranted) {
+     *                Toast.makeText(activity, "All permissions are granted", Toast.LENGTH_SHORT).show();
+     *            } else {
+     *                Toast.makeText(activity, "The following permissions are denied：" + deniedList, Toast.LENGTH_SHORT).show();
+     *            }
+     *     });
+     *     return null;
+     * });
+     * ```
+     * @param ctx the context which can launch a new activity
+     * @param block the request permissions block to be executed
+     */
+    @JvmStatic
+    fun delegate(ctx: Context, block: (activity: FragmentActivity) -> Unit) {
+        val uuid = UUID.randomUUID()
+        holder[uuid] = block
+        val intent = Intent(ctx, DelegateActivity::class.java)
+        intent.putExtra("uuid", uuid)
+        ctx.startActivity(intent)
+    }
+}

--- a/permissionx/src/main/java/com/permissionx/guolindev/request/PermissionBuilder.kt
+++ b/permissionx/src/main/java/com/permissionx/guolindev/request/PermissionBuilder.kt
@@ -21,6 +21,7 @@ import android.app.Dialog
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Build
+import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -33,6 +34,7 @@ import com.permissionx.guolindev.callback.RequestCallback
 import com.permissionx.guolindev.dialog.DefaultDialog
 import com.permissionx.guolindev.dialog.RationaleDialog
 import com.permissionx.guolindev.dialog.RationaleDialogFragment
+import com.permissionx.guolindev.patch.PermissionDelegateHolder
 import java.util.*
 
 /**
@@ -579,6 +581,10 @@ class PermissionBuilder(
      * Remove the InvisibleFragment from current FragmentManager.
      */
     private fun removeInvisibleFragment() {
+        // notify that the request is finished.
+        fragmentManager.setFragmentResult(PermissionDelegateHolder.REQUEST_KEY, Bundle().apply {
+            putBoolean(PermissionDelegateHolder.RESULT_KEY, true)
+        })
         val existedFragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG)
         if (existedFragment != null) {
             fragmentManager.beginTransaction().remove(existedFragment).commitNowAllowingStateLoss()


### PR DESCRIPTION
不改变原有代码结构，在PermissionX中增加一个新init方法，并使用一个frgment activity代理权限请求。
如此，不改变原用法基础上，任意可启动activity的context都可以申请权限，而不再限定FragmentActivity。这在compose中，不用再继承FragmentActivity。

新增加方法使用方式：
```
PermissionX.init(context) {
      //请求权限，与之前用法一致
      it.permissions(Manifest.permission.READ_CONTACTS, Manifest.permission.CAMERA)
        .request { allGranted, grantedList, deniedList ->
            
        }
}
```